### PR TITLE
Change meta data for icon to https

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,15 +8,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta property="og:description" content="See how Cogs.Red is doing">
     <meta property="og:title" content="Cogs.Red System Report">
-    <meta property="og:url" content="http://status.cogs.red">
-    <meta property="og:image" content="http://static.cogs.red/img/icon.png">
+    <meta property="og:url" content="https://status.cogs.red">
+    <meta property="og:image" content="https://static.cogs.red/img/icon.png">
     <meta property="og:type" content="website">
     <meta property="twitter:domain" content="status.cogs.red">
-    <meta property="twiiter:image" content="http://static.cogs.red/img/icon.png">
+    <meta property="twiiter:image" content="https://static.cogs.red/img/icon.png">
     <meta property="twitter:site" content="@orels1tips">
     <meta property="twitter:card" content="summary">
     <meta property="twitter:description" content="See how Cogs.Red is doing">
-    <link rel="icon" href="http://static.cogs.red/img/icon.png">
+    <link rel="icon" href="https://static.cogs.red/img/icon.png">
   </head>
   <body>
     <div id="statuspage"></div>


### PR DESCRIPTION
Change meta data for icon to https so that it will support HTTPS and not give a mixed content warning.